### PR TITLE
Fix for incorrectly decoded paths with accents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test/
+
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
 [Bb]in/
 [Oo]bj/

--- a/source/CachedImage.csproj
+++ b/source/CachedImage.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/source/FileCache.cs
+++ b/source/FileCache.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Security.Policy;
+using System.Web;
 
 namespace CachedImage
 {
@@ -30,8 +32,9 @@ namespace CachedImage
 
             // Cast the string into a Uri so we can access the image name without regex
             var uri = new Uri(url);
-            string localFile = string.Format("{0}\\{1}", AppCacheDirectory, uri.Segments[uri.Segments.Length - 1]);
-
+            var segment = uri.Segments[uri.Segments.Length - 1];
+            var urlDecode = HttpUtility.UrlDecode(segment);
+            string localFile = string.Format("{0}\\{1}", AppCacheDirectory, urlDecode);
             if (!File.Exists(localFile))
             {
                 HttpHelper.GetAndSaveToFile(url, localFile);


### PR DESCRIPTION
Hello !

Here's a fix for URLs with accents that were incorrectly saved and consequently triggered an exception.

Example:

`800px-David_Guetta_One_Love_Tour_México`

was saved to :

`800px-David_Guetta_One_Love_Tour_M%C3%A9xico`

Now it works it properly.

I'll let you know and PR if I find other issues.

Thank you :D
