### PR TITLE
Added the LoadAsync property allowing async loading of the image

### DIFF
--- a/source/Image.cs
+++ b/source/Image.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 
 // Thank you, Jeroen van Langen - http://stackoverflow.com/a/5175424/218882 and Ivan Leonenko - http://stackoverflow.com/a/12638859/218882
 
@@ -13,12 +15,15 @@ namespace CachedImage
     public class Image : System.Windows.Controls.Image
     {
         public static readonly DependencyProperty ImageUrlProperty = DependencyProperty.Register("ImageUrl",
-            typeof (string), typeof (Image), new PropertyMetadata("", ImageUrlPropertyChanged));
+            typeof(string), typeof(Image), new PropertyMetadata("", ImageUrlPropertyChanged));
+
+        public static readonly DependencyProperty LoadAsyncProperty = DependencyProperty.Register("LoadAsync",
+            typeof(bool), typeof(Image), new PropertyMetadata(false));
 
         static Image()
         {
-            DefaultStyleKeyProperty.OverrideMetadata(typeof (Image),
-                new FrameworkPropertyMetadata(typeof (Image)));
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(Image),
+                new FrameworkPropertyMetadata(typeof(Image)));
         }
 
         /// <summary>
@@ -26,24 +31,51 @@ namespace CachedImage
         /// </summary>
         public string ImageUrl
         {
-            get { return (string) GetValue(ImageUrlProperty); }
+            get { return (string)GetValue(ImageUrlProperty); }
             set { SetValue(ImageUrlProperty, value); }
         }
 
-        private static void ImageUrlPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+        public bool LoadAsync
         {
-            var url = (String) e.NewValue;
+            get { return (bool)GetValue(LoadAsyncProperty); }
+            set { SetValue(LoadAsyncProperty, value); }
+        }
+
+        private static async void ImageUrlPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+        {
+            var url = (String)e.NewValue;
+            var cachedImage = (Image)obj;
 
             if (String.IsNullOrEmpty(url))
                 return;
 
-            var cachedImage = (Image) obj;
+            if (cachedImage.LoadAsync)
+            {
+                cachedImage.Source = await LoadImageAsync(url);
+            }
+            else
+            {
+                cachedImage.Source = LoadImage(url);
+            }
+        }
+
+        private static Task<BitmapImage> LoadImageAsync(string url)
+        {
+            return Task.Run<BitmapImage>(() =>
+            {
+                return LoadImage(url);
+            });
+        }
+
+        private static BitmapImage LoadImage(string url)
+        {
             var bitmapImage = new BitmapImage();
             bitmapImage.BeginInit();
             bitmapImage.CacheOption = BitmapCacheOption.OnLoad;
             bitmapImage.UriSource = new Uri(FileCache.FromUrl(url));
             bitmapImage.EndInit();
-            cachedImage.Source = bitmapImage;
+            bitmapImage.Freeze();
+            return bitmapImage;
         }
     }
 }


### PR DESCRIPTION
Setting this property to true prevents the UI thread from freezing
(For example when loading large images or over a slow connection)

Notes:
- Freeze() is called on the bitmap before passing it between threads
- LoadAsync does not replace IsAsync in the binding,
  both can be combined for different behaviors
