### PR TITLE
Update FileCache.cs

### DIFF
--- a/source/FileCache.cs
+++ b/source/FileCache.cs
@@ -44,7 +44,7 @@ namespace CachedImage
         /// </summary>
         public static CacheMode AppCacheMode { get; set; }
 
-         public static async Task<MemoryStream> HitAsync(string url)
+        public static async Task<MemoryStream> HitAsync(string url)
         {
             if (!Directory.Exists(AppCacheDirectory))
             {


### PR DESCRIPTION
Fixed thrown exception when using dedicated cache mode  in .net core 3.1 apps, which was preventing downloading of the images in the first place.

Using Http client and getting the exact buffer of the downloaded content preventing the creation of the temporary buffer of hardcoded length 100 which wasn't reliable.