### PR TITLE
Fixed get an exception for URL with query params.

### DIFF
--- a/source/FileCache.cs
+++ b/source/FileCache.cs
@@ -58,7 +58,7 @@ namespace CachedImage
                 var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(canonicalUrl));
                 fileNameBuilder.Append(BitConverter.ToString(hash).Replace("-", "").ToLower());
                 if (Path.HasExtension(canonicalUrl))
-                    fileNameBuilder.Append(Path.GetExtension(canonicalUrl));
+                    fileNameBuilder.Append(Path.GetExtension(canonicalUrl).Split('?')[0]);
             }
 
             var fileName = fileNameBuilder.ToString();


### PR DESCRIPTION
Thrown an exception with a wrong character in the filename.
With url like this `https://i.ytimg.com/vi/tcYodQoapMg/hqdefault.jpg?sqp=-oaymwEiCKgBEF5IWvKriqkDFQgBFQAAAAAYASUAAMhCPQCAokN4AQ==&rs=AOn4CLCmYfyr2nJJUZu-CMSnkzBqT94X9Q`
